### PR TITLE
Deprecate AMI 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Site title and subtitle. This is used in _includes/header.html
-title: 'NCBI BLAST AMI'
+title: 'NCBI BLAST AMI (DEPRECATED)'
 subtitle: 'BLAST on the cloud'
 
 # Enable/show navigation. There are there options:

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ layout: page
 title: "NCBI BLAST Cloud Documentation"
 ---
 
-**The BLAST AMI has been deprecated and is no longer supported.  Please see our Cloud [documentation] (https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=CloudBlast) for other options.**
+**The BLAST AMI has been deprecated and is no longer supported.  Please see our Cloud [documentation](https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=CloudBlast) for other options.**
 
 
 

--- a/index.md
+++ b/index.md
@@ -3,7 +3,9 @@ layout: page
 title: "NCBI BLAST Cloud Documentation"
 ---
 
-*The BLAST AMI has been deprecated and is no longer supported.  Please see our BLAST+ Docker [documentation] (https://github.com/ncbi/blast_plus_docs) for a supported product.*
+**The BLAST AMI has been deprecated and is no longer supported.  Please see our Cloud [documentation] (https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=CloudBlast) for other options.**
+
+
 
 
 _Do you have difficulties running a large number of BLAST searches?<br>

--- a/index.md
+++ b/index.md
@@ -3,6 +3,9 @@ layout: page
 title: "NCBI BLAST Cloud Documentation"
 ---
 
+*The BLAST AMI has been deprecated and is no longer supported.  Please see our BLAST+ Docker [documentation] (https://github.com/ncbi/blast_plus_docs) for a supported product.*
+
+
 _Do you have difficulties running a large number of BLAST searches?<br>
 Do you have proprietary sequence data to BLAST and cannot use the NCBI BLAST web site?<br> 
 Do you want to avoid the work to set up and maintain the (command-line) BLAST+ applications?_<br>


### PR DESCRIPTION
Mark pages as deprecated.  Add link to current cloud pages,